### PR TITLE
Use same types for secondary search

### DIFF
--- a/src/ngAutocomplete.js
+++ b/src/ngAutocomplete.js
@@ -163,6 +163,7 @@ angular.module('ngAutocomplete', [])
               autocompleteService.getPlacePredictions(
                 {
                   input: result.name,
+                  types: [scope.options.types],
                   offset: result.name.length
                 },
                 function listentoresult (list, status) {


### PR DESCRIPTION
Secondary search of suggested places called without any types. This line fix that and use identical params for all usecases.
